### PR TITLE
Improve Flowzz scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# FlowzzInsight
+
+This utility gathers public statistics for cannabis flower strains listed on
+[flowzz.com](https://flowzz.com).  It queries the Flowzz CMS for available
+strains and scrapes each detail page to collect the number of likes and the
+average star rating.  The results are written to a CSV or JSON file and a
+compact ranking is printed to the console.
+
+## Usage
+
+```bash
+python flowzz_scraper.py --help
+```
+
+The command‐line interface lets you control the output location and format, the
+request delay and how many entries to display in the ranking tables.
+
+Example:
+
+```bash
+python flowzz_scraper.py -o results.csv -f csv --delay 1.0 --top 10
+```
+
+This will save a ``results.csv`` file and show the top 10 strains sorted by
+rating and by number of likes.
+


### PR DESCRIPTION
## Summary
- add README documentation
- add CLI options for output file, format, delay and top results
- export results to CSV or JSON
- print nicer ranking tables with strain URLs
- rename `main.py` to `flowzz_scraper.py`

## Testing
- `python3 -m py_compile flowzz_scraper.py`
- `python3 flowzz_scraper.py --help`

------
https://chatgpt.com/codex/tasks/task_e_688bb77f2bc88320a98bc8ac6499fcd1