### PR TITLE
Improve Flowzz scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# FlowzzInsight
+
+This utility scrapes strain statistics from [flowzz.com](https://flowzz.com).
+It queries the public CMS for available strains and then fetches each strain's
+page to extract the number of likes and the average user rating.
+
+## Features
+
+- Concurrent scraping for faster execution
+- Command line interface with options for concurrency and request delay
+- Results saved to CSV and/or JSON if desired
+- Nicely formatted tables with direct links to each strain
+
+## Usage
+
+Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the scraper:
+
+```bash
+python main.py --csv strains.csv --json strains.json --limit 30
+```
+
+This will print the top strains by rating and likes, while also writing all
+scraped data to `strains.csv` and `strains.json`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+tqdm
+tabulate


### PR DESCRIPTION
## Summary
- add concurrent scraping and CLI options
- support CSV/JSON exports
- present tables using `tabulate`
- document features and usage in README
- provide requirements.txt for dependencies

## Testing
- `pip install -r requirements.txt`
- `python main.py --help | head`


------
https://chatgpt.com/codex/tasks/task_e_688bb77f2bc88320a98bc8ac6499fcd1