### PR TITLE
Enhance Flowzz strain scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# FlowzzInsight
+
+This tool scrapes publicly available statistics about cannabis flower strains from [flowzz.com](https://flowzz.com).
+It collects each strain's likes and user rating and stores the data in a CSV or JSON file.
+
+## Usage
+
+Run the scraper with Python 3:
+
+```bash
+python main.py [-o OUTPUT] [--json] [--no-tables]
+```
+
+- `-o`, `--output`  Path to the file where results are written (default: `strain_data.csv`).
+- `--json`          Save the results in JSON format instead of CSV.
+- `--no-tables`     Suppress printing summary tables to the console.
+
+Example:
+
+```bash
+python main.py -o strains.json --json
+```
+
+The script iterates through all strains exposed by the Flowzz CMS, retrieves
+statistics from each strain page, and writes the aggregated data to the chosen
+output file.  A small delay between requests keeps the load on Flowzz's servers
+low.
+


### PR DESCRIPTION
## Summary
- overhaul `main.py` with command line interface
- export strain data to CSV/JSON
- print summary tables with direct strain links
- document new usage options in `README.md`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_688bb77f2bc88320a98bc8ac6499fcd1