### PR TITLE
Add pharmacy finder utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# FlowzzInsight
+
+Utilities for interacting with the public API of [flowzz.com](https://flowzz.com). The project contains a scraper for product data and a simple viewer built with Streamlit.
+
+## Requirements
+
+- Python 3.11+
+- `requests`
+- `pandas`
+- `streamlit` (for the viewer)
+
+Install dependencies via pip:
+
+```bash
+pip install requests pandas streamlit
+```
+
+## Product Scraper
+
+`flowzz_product_scraper.py` downloads metadata about all cannabis flower products and writes CSV files sorted by likes and rating.
+
+Run the scraper:
+
+```bash
+python flowzz_product_scraper.py
+```
+
+## Pharmacy Finder
+
+`flowzz_pharmacy_finder.py` helps to locate pharmacies that stock selected strains. It mimics the pharmacy search behaviour of the [Flowzz Shopping Helper](https://github.com/FrittenToni/flowzz-shopping-helper).
+
+When executed it downloads the list of strains, lets you enter up to three strain names and then queries the pharmacy API to find vendors that offer **all** of them.
+
+```bash
+python flowzz_pharmacy_finder.py
+```
+
+The script prints a table with vendor names and prices. Note that network access to `flowzz.com` is required for it to work.
+

--- a/flowzz_pharmacy_finder.py
+++ b/flowzz_pharmacy_finder.py
@@ -1,0 +1,113 @@
+# flowzz_pharmacy_finder.py
+"""Utility to find pharmacies offering specific cannabis strains."""
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+import requests
+import pandas as pd
+
+import flowzz_product_scraper as scraper
+
+VENDOR_API = "https://flowzz.com/api/vendor?t=2&id={id}"
+
+@dataclass
+class VendorInfo:
+    name: str
+    price: float
+    website: str | None
+
+
+def fetch_vendors_for_strain(strain_id: int) -> List[VendorInfo]:
+    """Return a list of vendors offering a given strain."""
+    url = VENDOR_API.format(id=strain_id)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    data = resp.json()
+
+    vendors = []
+    price_flowers = (
+        data.get("message", {}).get("data", {}).get("priceFlowers", {}).get("data", [])
+    )
+    for item in price_flowers:
+        attr = item.get("attributes", {})
+        avail = attr.get("availibility")
+        if avail not in (1, 2):
+            continue
+        vendor_data = attr.get("vendor", {}).get("data", {})
+        vendor_attr = vendor_data.get("attributes", {})
+        vendors.append(
+            VendorInfo(
+                name=vendor_attr.get("name"),
+                price=float(attr.get("price")),
+                website=vendor_attr.get("website"),
+            )
+        )
+    return vendors
+
+
+def find_common_vendors(strain_ids: List[int]) -> pd.DataFrame:
+    """Return vendors that offer all given strains with price summary."""
+    vendor_maps: List[Dict[str, VendorInfo]] = []
+    for sid in strain_ids:
+        vendors = fetch_vendors_for_strain(sid)
+        vmap = {v.name: v for v in vendors}
+        vendor_maps.append(vmap)
+
+    if not vendor_maps:
+        return pd.DataFrame()
+
+    common_names = set(vendor_maps[0].keys())
+    for vmap in vendor_maps[1:]:
+        common_names &= set(vmap.keys())
+
+    rows = []
+    for name in common_names:
+        total = 0.0
+        websites = []
+        prices = []
+        for vmap in vendor_maps:
+            v = vmap[name]
+            total += v.price
+            prices.append(v.price)
+            if v.website:
+                websites.append(v.website)
+        rows.append({"vendor": name, "total_price": total, **{f"price_{i+1}": p for i, p in enumerate(prices)}, "websites": ", ".join(websites)})
+
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df = df.sort_values("total_price")
+    return df
+
+
+def main() -> None:
+    print("Fetching strain catalogue…")
+    products = scraper.fetch_all_products(page_size=100, delay=0.1)
+    options = {p.name: p.id for p in products}
+
+    print("Enter up to 3 strain names (exact as listed). Leave blank to finish:")
+    selected_ids = []
+    for i in range(3):
+        name = input(f"Strain {i+1}: ").strip()
+        if not name:
+            break
+        sid = options.get(name)
+        if sid is None:
+            print("Unknown strain. Try again.")
+            continue
+        selected_ids.append(sid)
+    if not selected_ids:
+        print("No strains selected.")
+        return
+
+    print("Finding pharmacies…")
+    df = find_common_vendors(selected_ids)
+    if df.empty:
+        print("No pharmacy carries all selected strains.")
+        return
+    print(df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a script to query vendor data for selected strains
- document pharmacy finder and basic usage

## Testing
- `python -m py_compile flowzz_product_scraper.py flowzz_pharmacy_finder.py flowzz_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_688c98d8e0d8832089bb87f4002906cd