### PR TITLE
Add clickable link column to viewer

### DIFF
--- a/flowzz_viewer.py
+++ b/flowzz_viewer.py
@@ -32,6 +32,12 @@ if st.button("Daten aktualisieren"):
 
 df = st.session_state["df"]
 
+# Spalte mit klickbarem Link einfügen und alte Link-Spalte entfernen
+if "product_link" in df.columns:
+    link_index = list(df.columns).index("name") + 1
+    df.insert(link_index, "Produktseite", df["product_link"])
+    df.drop(columns=["product_link"], inplace=True)
+
 # -------- Filter in der Sidebar --------
 st.sidebar.header("Filter")
 
@@ -111,6 +117,9 @@ edited_df = st.data_editor(
     use_container_width=True,
     hide_index=True,
     key="product_editor",
+    column_config={
+        "Produktseite": st.column_config.LinkColumn("", display_text="🔗")
+    },
 )
 
 # Download


### PR DESCRIPTION
## Summary
- add interactive product link column next to product name in viewer
- drop the old text link column and use Streamlit LinkColumn in data editor

## Testing
- `python -m py_compile flowzz_product_scraper.py flowzz_pharmacy_helper.py flowzz_viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_688cb9f28aa08320b010865814553e8e