### PR TITLE
Add selective strain refresh

### DIFF
--- a/flowzz_product_scraper.py
+++ b/flowzz_product_scraper.py
@@ -235,6 +235,32 @@ def fetch_product_likes(session: requests.Session, slug: str) -> Optional[int]:
     return attributes.get("num_likes")
 
 
+def fetch_product_detail(
+    slug: str, session: Optional[requests.Session] = None
+) -> ProductDetails:
+    """Return complete product information for a single slug."""
+    if session is None:
+        session = requests.Session()
+    url = f"{API_BASE}/{slug}"
+    resp = session.get(url)
+    resp.raise_for_status()
+    data = resp.json().get("data", {})
+    attrs = data.get("attributes", {})
+    return ProductDetails(
+        id=data.get("id"),
+        name=attrs.get("name"),
+        thc=attrs.get("thc"),
+        cbd=attrs.get("cbd"),
+        ratings_score=attrs.get("ratings_score"),
+        ratings_count=attrs.get("ratings_count"),
+        min_price=attrs.get("min_price"),
+        max_price=attrs.get("max_price"),
+        slug=slug,
+        num_likes=attrs.get("num_likes") or data.get("num_likes"),
+        product_link=f"https://flowzz.com/product/{slug}",
+    )
+
+
 def enrich_products_with_likes(
     products: List[ProductSummary], delay: float = 0.5
 ) -> List[ProductDetails]:

--- a/flowzz_viewer.py
+++ b/flowzz_viewer.py
@@ -130,6 +130,35 @@ edited_df = st.data_editor(
     ),
 )
 
+# Button to refresh selected strains
+selected_ids = edited_df[edited_df["Auswahl"]].index.tolist()
+if st.button("Ausgewählte aktualisieren"):
+    if not selected_ids:
+        st.warning("Bitte mindestens eine Sorte auswählen")
+    else:
+        with st.spinner("Aktualisiere Sorten..."):
+            new_rows = []
+            for sid in selected_ids:
+                slug = df.loc[df["id"] == sid, "slug"].values[0]
+                detail = scraper.fetch_product_detail(slug)
+                new_rows.append(detail)
+            for detail in new_rows:
+                df.loc[df["id"] == detail.id, :] = [
+                    detail.id,
+                    detail.name,
+                    detail.thc,
+                    detail.cbd,
+                    detail.ratings_score,
+                    detail.ratings_count,
+                    detail.num_likes,
+                    detail.min_price,
+                    detail.max_price,
+                    detail.slug,
+                    detail.product_link,
+                ]
+        st.session_state["df"] = df
+        df.to_csv(CSV_PATH, index=False)
+
 # Download
 st.download_button(
     "CSV exportieren",


### PR DESCRIPTION
## Summary
- add helper to fetch single product details
- add Streamlit button to refresh selected strains

## Testing
- `python -m py_compile flowzz_viewer.py flowzz_product_scraper.py flowzz_pharmacy_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_688cf77e07888320a13ed83644c46b15